### PR TITLE
Remove links to Mitaka worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,9 +81,6 @@
                     <li>
                       <a href="https://trunk.rdoproject.org/centos7-newton/report.html">CentOS 7 stable/newton</a>
                     </li>
-                    <li>
-                      <a href="https://trunk.rdoproject.org/centos7-mitaka/report.html">CentOS 7 stable/mitaka</a>
-                    </li>
                   </ul>
                   <h3>Latest (untested!) trunk repos</h3>
                   <ul>
@@ -101,9 +98,6 @@
                     </li>
                     <li>
                       <a href="https://trunk.rdoproject.org/centos7-newton/current/">CentOS 7 stable/newton</a>, <a href="https://trunk.rdoproject.org/centos7-newton/current/delorean.repo">repo</a>
-                    </li>
-                    <li>
-                      <a href="https://trunk.rdoproject.org/centos7-mitaka/current/">CentOS 7 stable/mitaka</a>, <a href="https://trunk.rdoproject.org/centos7-mitaka/current/delorean.repo">repo</a>
                     </li>
                   </ul>
                   <h3>RDO Trunk infrastructure administrators</h3>


### PR DESCRIPTION
Mitaka is now EOL, so we need to remove it from the index.