### PR TITLE
Add Mock configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
                       <a href="https://trunk.rdoproject.org/f25/report.html">Fedora rawhide master</a>
                     </li>
                     <li>
-                      <a href="https://trunk.rdoproject.org/centos7-master/report.html">CentOS 7 master (using current tagged releases)</a> <a href="#footnote1">[*]</a>
+                      <a href="https://trunk.rdoproject.org/centos7-master/report.html">CentOS 7 master (using current tagged releases)</a> <a href="#footnote1">[*]</a> <a href="rdo-trunk-pike-centos7-x86_64.cfg">Mock configuration for fedora-review</a>
                     </li>
                     <li>
                       <a href="https://trunk.rdoproject.org/centos7-master-head/report.html">CentOS 7 master</a>

--- a/rdo-trunk-pike-centos7-x86_64.cfg
+++ b/rdo-trunk-pike-centos7-x86_64.cfg
@@ -1,0 +1,58 @@
+config_opts['root'] = 'rdo-trunk-pike-centos7-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['chroot_setup_cmd'] = 'install basesystem rpm-build python2-devel gcc make python-sqlalchemy python-webob ghostscript graphviz python-sphinx python-eventlet python-six python-pbr python3-pbr openstack-macros git g++'
+config_opts['dist'] = 'el7'  # only useful for --resultdir variable subst
+config_opts['releasever'] = '7'
+config_opts['plugin_conf']['ccache_enable'] = False
+
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+
+# repos
+
+[base]
+name=BaseOS
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os
+failovermethod=priority
+gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-CentOS-7
+gpgcheck=1
+
+[updates]
+name=updates
+enabled=1
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=updates
+failovermethod=priority
+gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-CentOS-7
+gpgcheck=1
+
+[extras]
+name=extras
+mirrorlist=http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=extras
+failovermethod=priority
+gpgkey=file:///etc/pki/mock/RPM-GPG-KEY-EPEL-7
+gpgcheck=1
+
+[rdo-pike-testing]
+name=RDO Pike testing
+baseurl=http://buildlogs.centos.org/centos/7/cloud/$basearch/openstack-pike/
+enabled=1
+gpgcheck=0
+
+[rdo-trunk-pike]
+name=RDO Trunk Pike
+baseurl=http://trunk.rdoproject.org/centos7-pike/current
+enabled=1
+gpgcheck=0
+priority=1
+"""


### PR DESCRIPTION
For using in RDO Package Reviews with fedora-review --mock-config
needs to be copied to /etc/mock/