### PR TITLE
Add links to stable/pike worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,9 @@
                       <a href="https://trunk.rdoproject.org/centos7-master-head/report.html">CentOS 7 master</a>
                     </li>
                     <li>
+                      <a href="https://trunk.rdoproject.org/centos7-pike/report.html">CentOS 7 stable/pike</a>
+                    </li>
+                    <li>
                       <a href="https://trunk.rdoproject.org/centos7-ocata/report.html">CentOS 7 stable/ocata</a>
                     </li>
                     <li>
@@ -94,6 +97,9 @@
                   <h3>Latest (untested!) stable branch trunk repos</h3>
                   <ul>
                     <li>
+                      <a href="https://trunk.rdoproject.org/centos7-pike/current/">CentOS 7 stable/pike</a>, <a href="https://trunk.rdoproject.org/centos7-pike/current/delorean.repo">repo</a>
+                    </li>
+                    <li>
                       <a href="https://trunk.rdoproject.org/centos7-ocata/current/">CentOS 7 stable/ocata</a>, <a href="https://trunk.rdoproject.org/centos7-ocata/current/delorean.repo">repo</a>
                     </li>
                     <li>
@@ -104,6 +110,9 @@
                   <ul>
                     <li>
                       <a href="https://trunk.rdoproject.org/centos7-master/queue.html">Centos-master-uc (master)</a>
+                    </li>
+                    <li>
+                      <a href="https://trunk.rdoproject.org/centos7-pike/queue.html">Centos-pike (stable/pike)</a>
                     </li>
                     <li>
                       <a href="https://trunk.rdoproject.org/centos7-ocata/queue.html">Centos-ocata (stable/ocata)</a>


### PR DESCRIPTION
The stable/pike worker is now configured, even if not all projects
have created their branches. Let's add the links.