### PR TITLE
Remove EOL'd releases

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,15 +87,6 @@
                     <li>
                       <a href="https://trunk.rdoproject.org/centos7-queens/report.html">CentOS 7 stable/queens</a>
                     </li>
-                    <li>
-                      <a href="https://trunk.rdoproject.org/centos7-pike/report.html">CentOS 7 stable/pike</a>
-                    </li>
-                    <li>
-                      <a href="https://trunk.rdoproject.org/centos7-ocata/report.html">CentOS 7 stable/ocata</a>
-                    </li>
-                    <li>
-                      <a href="https://trunk.rdoproject.org/centos7-newton/report.html">CentOS 7 stable/newton</a>
-                    </li>
                   </ul>
                   <h3>Latest (untested!) trunk repos</h3>
                   <ul>
@@ -120,15 +111,6 @@
                     <li>
                       <a href="https://trunk.rdoproject.org/centos7-queens/current/">CentOS 7 stable/queens</a>, <a href="https://trunk.rdoproject.org/centos7-queens/current/delorean.repo">repo</a>
                     </li>
-                    <li>
-                      <a href="https://trunk.rdoproject.org/centos7-pike/current/">CentOS 7 stable/pike</a>, <a href="https://trunk.rdoproject.org/centos7-pike/current/delorean.repo">repo</a>
-                    </li>
-                    <li>
-                      <a href="https://trunk.rdoproject.org/centos7-ocata/current/">CentOS 7 stable/ocata</a>, <a href="https://trunk.rdoproject.org/centos7-ocata/current/delorean.repo">repo</a>
-                    </li>
-                    <li>
-                      <a href="https://trunk.rdoproject.org/centos7-newton/current/">CentOS 7 stable/newton</a>, <a href="https://trunk.rdoproject.org/centos7-newton/current/delorean.repo">repo</a>
-                    </li>
                   </ul>
                   <h3>Pending commits for the current run</h3>
                   <ul>
@@ -143,15 +125,6 @@
                     </li>
                     <li>
                       <a href="https://trunk.rdoproject.org/centos7-queens/queue.html">Centos-queens (stable/queens)</a>
-                    </li>
-                    <li>
-                      <a href="https://trunk.rdoproject.org/centos7-pike/queue.html">Centos-pike (stable/pike)</a>
-                    </li>
-                    <li>
-                      <a href="https://trunk.rdoproject.org/centos7-ocata/queue.html">Centos-ocata (stable/ocata)</a>
-                    </li>
-                    <li>
-                      <a href="https://trunk.rdoproject.org/centos7-newton/queue.html">Centos-newton (stable/newton)</a>
                     </li>
                   </ul>
                   <h3>RDO Trunk infrastructure administrators</h3>


### PR DESCRIPTION
Pike, Ocata and Newton are not longer supported in RDO, so let's remove
them from the RDO Trunk homepage.