### PR TITLE
Add links for Train DRLN builders

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,9 @@
                       <a href="https://trunk.rdoproject.org/centos7-master-head/report.html">CentOS 7 master</a>
                     </li>
                     <li>
+                      <a href="https://trunk.rdoproject.org/centos7-train/report.html">CentOS 7 stable/train</a>
+                    </li>
+                    <li>
                       <a href="https://trunk.rdoproject.org/centos7-stein/report.html">CentOS 7 stable/stein</a>
                     </li>
                     <li>
@@ -103,6 +106,9 @@
                       <a href="https://trunk.rdoproject.org/fedora28-stein/current/">Fedora 28 Stabilized stable/stein</a>, <a href="https://trunk.rdoproject.org/fedora28-stein/current/delorean.repo">repo</a>
                     </li>
                     <li>
+                      <a href="https://trunk.rdoproject.org/centos7-train/current/">CentOS 7 stable/train</a>, <a href="https://trunk.rdoproject.org/centos7-train/current/delorean.repo">repo</a>
+                    </li>
+                    <li>
                       <a href="https://trunk.rdoproject.org/centos7-stein/current/">CentOS 7 stable/stein</a>, <a href="https://trunk.rdoproject.org/centos7-stein/current/delorean.repo">repo</a>
                     </li>
                     <li>
@@ -116,6 +122,9 @@
                   <ul>
                     <li>
                       <a href="https://trunk.rdoproject.org/centos7-master/queue.html">Centos-master-uc (master)</a>
+                    </li>
+                    <li>
+                      <a href="https://trunk.rdoproject.org/centos7-train/queue.html">Centos-train (stable/train)</a>
                     </li>
                     <li>
                       <a href="https://trunk.rdoproject.org/centos7-stein/queue.html">Centos-stein (stable/stein)</a>


### PR DESCRIPTION
Adding the links for Train release.
Note that there is not link for fedora28-train, since we are planing to move to CentOS8 during the cycle.
See https://github.com/rdo-infra/puppet-dlrn/commit/478db24197f60d3959e4264f748d3a983e64d616 for more informations.