### PR TITLE
Remove fedora repos and add CentOS8

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,10 +67,10 @@
                   <h3>Lastest Build Reports</h3>
                   <ul>
                     <li>
-                      <a href="https://trunk.rdoproject.org/fedora/report.html">Fedora 28 Stabilized master</a>
+                      <a href="https://trunk.rdoproject.org/centos8-master/report.html">CentOS 8 master</a>
                     </li>
                     <li>
-                      <a href="https://trunk.rdoproject.org/fedora28-stein/report.html">Fedora 28 Stabilized stable/stein</a>
+                      <a href="https://trunk.rdoproject.org/centos8-train/report.html">CentOS 8 stable/train</a>
                     </li>
                     <li>
                       <a href="https://trunk.rdoproject.org/centos7-master/report.html">CentOS 7 master (using current tagged releases)</a> <a href="#footnote1">[*]</a>
@@ -94,7 +94,7 @@
                   <h3>Latest (untested!) trunk repos</h3>
                   <ul>
                     <li>
-                      <a href="https://trunk.rdoproject.org/fedora/current/">Fedora 28 Stabilized master</a>, <a href="https://trunk.rdoproject.org/fedora/current/delorean.repo">repo</a>
+                      <a href="https://trunk.rdoproject.org/centos8-master/current/">CentOS 8 master</a>, <a href="https://trunk.rdoproject.org/centos8-master/current/delorean.repo">repo</a>
                     </li>
                     <li>
                       <a href="https://trunk.rdoproject.org/centos7-master/current/">CentOS 7 master</a>, <a href="https://trunk.rdoproject.org/centos7-master/current/delorean.repo">repo</a>
@@ -103,7 +103,7 @@
                   <h3>Latest (untested!) stable branch trunk repos</h3>
                   <ul>
                     <li>
-                      <a href="https://trunk.rdoproject.org/fedora28-stein/current/">Fedora 28 Stabilized stable/stein</a>, <a href="https://trunk.rdoproject.org/fedora28-stein/current/delorean.repo">repo</a>
+                      <a href="https://trunk.rdoproject.org/centos8-train/current/">CentOS 8 stable/train</a>, <a href="https://trunk.rdoproject.org/centos8-train/current/delorean.repo">repo</a>
                     </li>
                     <li>
                       <a href="https://trunk.rdoproject.org/centos7-train/current/">CentOS 7 stable/train</a>, <a href="https://trunk.rdoproject.org/centos7-train/current/delorean.repo">repo</a>
@@ -120,6 +120,9 @@
                   </ul>
                   <h3>Pending commits for the current run</h3>
                   <ul>
+                    <li>
+                      <a href="https://trunk.rdoproject.org/centos8-master/queue.html">CentOS 8 master-uc (master)</a>
+                    </li>
                     <li>
                       <a href="https://trunk.rdoproject.org/centos7-master/queue.html">Centos-master-uc (master)</a>
                     </li>


### PR DESCRIPTION
Fedora repos have been retired and CentOS8 ones added for master and
train.