### PR TITLE
Added links to Ussuri DLRN builds

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,9 @@
                       <a href="https://trunk.rdoproject.org/centos8-master/report.html">CentOS 8 master</a>
                     </li>
                     <li>
+                      <a href="https://trunk.rdoproject.org/centos8-ussuri/report.html">CentOS 8 stable/ussuri</a>
+                    </li>
+                    <li>
                       <a href="https://trunk.rdoproject.org/centos8-train/report.html">CentOS 8 stable/train</a>
                     </li>
                     <li>
@@ -103,6 +106,9 @@
                   <h3>Latest (untested!) stable branch trunk repos</h3>
                   <ul>
                     <li>
+                      <a href="https://trunk.rdoproject.org/centos8-ussuri/current/">CentOS 8 stable/ussuri</a>, <a href="https://trunk.rdoproject.org/centos8-ussuri/current/delorean.repo">repo</a>
+                    </li>
+                    <li>
                       <a href="https://trunk.rdoproject.org/centos8-train/current/">CentOS 8 stable/train</a>, <a href="https://trunk.rdoproject.org/centos8-train/current/delorean.repo">repo</a>
                     </li>
                     <li>
@@ -122,6 +128,9 @@
                   <ul>
                     <li>
                       <a href="https://trunk.rdoproject.org/centos8-master/queue.html">CentOS 8 master-uc (master)</a>
+                    </li>
+                    <li>
+                      <a href="https://trunk.rdoproject.org/centos8-ussuri/queue.html">CentOS 8 ussuri (stable/ussuri)</a>
                     </li>
                     <li>
                       <a href="https://trunk.rdoproject.org/centos7-master/queue.html">Centos-master-uc (master)</a>


### PR DESCRIPTION
Ussuri release has been bootstrapped on trunk.rdoproject.org.
Let's update links on web page.
