### PR TITLE
Migrate to ansible-role-dlrn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# trunk.rdoproject.org landing page
+The repository contents have been migrated to the [ansible-role-dlrn](https://github.com/rdo-infra/ansible-role-dlrn) repo.


### PR DESCRIPTION
This commit updates the README.md file to notify that the repo
has been migrated to be part of ansible-role-dlrn with [1].

[1] - https://review.rdoproject.org/r/31973